### PR TITLE
Remove Cold Aunder II as Noir can't place the wool.

### DIFF
--- a/Beta/medium
+++ b/Beta/medium
@@ -1,4 +1,3 @@
-Cold Aunder II
 BoomBox
 Abudor II
 Wit's Ending


### PR DESCRIPTION
The team Noir- grey team (bad colour for a team) can't place the wool however the other team can.

Likely that the monument location is in the incorrect location. Should probs of been picked up on before the map made it into both the repo and the rotation.

Looks like you take issues not pull-requests, I guess you can use this and take the easy way out or pretend this is an issue not a pr. Whoops 💯 